### PR TITLE
feat: アカウント作成用コントローラー追加

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,9 @@
+# アカウント作成用コントローラー
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+    private
+
+    def sign_up_params
+        params.permit(:email, :password, :password_confirmation, :name)
+    end
+end

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Auth::SessionsController < ApplicationController
+    def index
+        # current_api_v1_userはdeviseのメソッド
+        if current_api_v1_user
+            render json: { status: 200, current_user: current_api_v1_user }
+        else
+            render json: { status: 500, message: "ユーザーが存在しません" }
+        end
+    end
+end
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
-class ApplicationController < ActionController::API
-        include DeviseTokenAuth::Concerns::SetUserByToken
+class ApplicationController < ActionController::Base
+  include DeviseTokenAuth::Concerns::SetUserByToken
+
+  skip_before_action :verify_authenticity_token
+  helper_method :current_user, :user_signed_in?
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '4456c2dae81d07e015183b467a552cc07509fe090702e2b26e1b19d24088db4e71f7d4eafff0b3bf48431511632edfcc030c376105116023dc956531cac27fee'
+  # config.secret_key = '5ac0646c58212c64cff1eb180c366bc04034d77e941853e1d98690ba27079aa57a2b4f7b038ef762a9ed0f40e04d1333b6154784d91e66a808a304ae27ca824a'
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -126,7 +126,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 12
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = '9c4f417169db2cf9912bad1fcb74c67296a0118ad2e142099fffb49c9653216b599e703badb9e68dfc2e314b81a693f4aead93c66b986acf07ca14d02e73615c'
+  # config.pepper = '400b312f06694958d961f2fc286807ab3a5501ee626609e22c78540580ab506240fea31e9231639e6575773496af3d4506f2d5bed3bd2e61108e2f4c01a1d60b'
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -9,6 +9,6 @@ DeviseTokenAuth.setup do |config|
                          :'client' => 'client',
                          :'expiry' => 'expiry',
                          :'uid' => 'uid',
-                         :'token-type' => 'token-type' }
+                         :'token-type' => 'token-type',
+                         :'authorization' => 'authorization'}
 end
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,15 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
   namespace :api do
     namespace :v1 do
       resources :test, only: %i[index]
+
+      mount_devise_token_auth_for 'User', at: 'auth', controllers: {
+        registrations: 'api/v1/auth/registrations'
+      }
+
+      namespace :auth do
+        resources :sessions, only: %i[index]
+      end
     end
   end
 end

--- a/test/controllers/api/v1/auth/registrations_controller_test.rb
+++ b/test/controllers/api/v1/auth/registrations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::Auth::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/api/v1/auth/sessions_controller_test.rb
+++ b/test/controllers/api/v1/auth/sessions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::Auth::SessionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
アカウント作成用のコントローラーなど追加

# 動作確認

```
fukuishunichi@fukuishunichinoMacBook-Pro backend % curl -X POST http://localhost:3001/api/v1/auth -d "[name]=test&[email]=test@example.com&[password]=password&[password_confirmation]=password"
{"status":"success","data":{"id":1,"provider":"email","uid":"test@example.com","allow_password_change":false,"name":"test","nickname":null,"image":null,"email":"test@example.com","created_at":"2024-06-16T10:15:42.560Z","updated_at":"2024-06-16T10:15:42.615Z"}}%                                                                                                               fukuishunichi@fukuishunichinoMacBook-Pro backend % curl -X POST -v http://localhost:3001/api/v1/auth/sign_in -d "[email]=test@example.com&[password]=password"
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:3001...
* Connected to localhost (127.0.0.1) port 3001 (#0)
> POST /api/v1/auth/sign_in HTTP/1.1
> Host: localhost:3001
> User-Agent: curl/7.87.0
> Accept: */*
> Content-Length: 44
> Content-Type: application/x-www-form-urlencoded
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Referrer-Policy: strict-origin-when-cross-origin
< Content-Type: application/json; charset=utf-8
< access-token: 49FxaDtI6VQWPnh0yP44JA
< token-type: Bearer
< client: ZfcdL8aKRtH3hbqVpHpvLQ
< expiry: 1719742552
< uid: test@example.com
< authorization: Bearer eyJhY2Nlc3MtdG9rZW4iOiI0OUZ4YUR0STZWUVdQbmgweVA0NEpBIiwidG9rZW4tdHlwZSI6IkJlYXJlciIsImNsaWVudCI6IlpmY2RMOGFLUnRIM2hicVZwSHB2TFEiLCJleHBpcnkiOiIxNzE5NzQyNTUyIiwidWlkIjoidGVzdEBleGFtcGxlLmNvbSJ9
< ETag: W/"66643f3790be1f52d2e42cd97587a4bf"
< Cache-Control: max-age=0, private, must-revalidate
< X-Request-Id: 295265fe-7e66-470c-a880-23b57c8b0adf
< X-Runtime: 0.315829
< vary: Accept, Origin
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
{"data":{"email":"test@example.com","provider":"email","uid":"test@example.com","id":1,"allow_password_change":false,"name":"test","nickname":null,"image":null}}%
```